### PR TITLE
[feat/Refacotr] 노래 조회시 댓글도 조회 / 예외처리 관련 리팩토링 및 방식 수정 / 충돌 해결 등

### DIFF
--- a/src/main/java/org/example/merong/domain/songs/SongController.java
+++ b/src/main/java/org/example/merong/domain/songs/SongController.java
@@ -40,7 +40,7 @@ public class SongController {
         return ResponseEntity.status(songService.updateSong(userDetail.getUser().getId(), songId, dto), HttpStatus.OK);
     }
     // 4. 노래 삭제
-    @PatchMapping("/{songid}")
+    @DeleteMapping("/{songid}")
     public ResponseEntity<Void> deleteSong(@AuthenticationPrincipal CustomUserDetails userDetail,
                                            @PathVariable Long songid) {
 

--- a/src/main/java/org/example/merong/domain/songs/SongRepository.java
+++ b/src/main/java/org/example/merong/domain/songs/SongRepository.java
@@ -1,9 +1,19 @@
 package org.example.merong.domain.songs;
 
 import org.example.merong.domain.songs.entity.Song;
+import org.example.merong.domain.songs.exception.SongException;
+import org.example.merong.domain.songs.exception.SongsExceptionCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface SongRepository extends JpaRepository<Song, Long> {
+
+    Optional<Song> findById(Long songId);
+
+    default Song findByIdOrElseThrow(Long songId) {
+        return findById(songId).orElseThrow(() -> new SongException(SongsExceptionCode.SONG_NOT_FOUND));
+    }
 }

--- a/src/main/java/org/example/merong/domain/songs/SongService.java
+++ b/src/main/java/org/example/merong/domain/songs/SongService.java
@@ -5,7 +5,9 @@ import org.example.merong.domain.songs.dto.request.SongRequestDto;
 import org.example.merong.domain.songs.dto.request.SongUpdateDto;
 import org.example.merong.domain.songs.dto.response.SongResponseDto;
 import org.example.merong.domain.songs.entity.Song;
-import org.example.merong.domain.users.entity.User;
+import org.example.merong.domain.songs.exception.SongException;
+import org.example.merong.domain.songs.exception.SongsExceptionCode;
+import org.example.merong.domain.user.entity.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,39 +23,40 @@ public class SongService {
     private final UserRepository userRepository;
 
     // 1. 노래 등록
-    public SongResponseDto createSong(Long userId, SongRequestDto dto) {
+    public SongResponseDto.Create createSong(Long userId, SongRequestDto dto) {
 
         User currentUser = userRepository.findById(userId).orElseThrow(() -> new RuntimeException());
 
         Song song = songRepository.save(new Song(dto));
 
-        return new SongResponseDto(song);
+        return new SongResponseDto.Create(song);
     }
 
     // 2. 내 노래 전체 조회
     @Transactional(readOnly = true)
-    public List<SongResponseDto> getSongs(Long userId) {
+    public List<SongResponseDto.Get> getSongs(Long userId) {
 
         User currentUser = userRepository.findById(userId).orElseThrow(() -> new RuntimeException());
 
-        return currentUser.getSongs().stream().map(SongResponseDto::new).collect(Collectors.toList());
+        return currentUser.getSongs().stream().map(SongResponseDto.Get::new).collect(Collectors.toList());
 
     }
+
     // 3. 노래 수정
-    public SongResponseDto updateSong(Long userId, Long songId, SongUpdateDto dto) {
+    public SongResponseDto.Update updateSong(Long userId, Long songId, SongUpdateDto dto) {
 
         User currentUser = userRepository.findById(userId).orElseThrow(() -> new RuntimeException());
-        Song song = songRepository.findById(songId).orElseThrow(() -> new RuntimeException());
+        Song song = songRepository.findByIdOrElseThrow(songId);
 
         // 검증
-        if(currentUser.getId().equals(song.getUser().getId())) {
-           throw new RuntimeException("정보가 일치하지 않습니다.");
+        if (currentUser.getId().equals(song.getUser().getId())) {
+            throw new SongException(SongsExceptionCode.SONG_OWNERSHIP_EXCEPTION);
         }
 
         song.updateSong(dto);
         songRepository.save(song);
 
-        return new SongResponseDto(song);
+        return new SongResponseDto.Update(song);
 
     }
 
@@ -61,11 +64,11 @@ public class SongService {
     public void deleteSong(Long userId, Long songId) {
 
         User currentUser = userRepository.findById(userId).orElseThrow(() -> new RuntimeException());
-        Song song = songRepository.findById(songId).orElseThrow(() -> new RuntimeException());
+        Song song = songRepository.findByIdOrElseThrow(songId);
 
         // 검증
-        if(currentUser.getId().equals(song.getUser().getId())) {
-            throw new RuntimeException("정보가 일치하지 않습니다.");
+        if (currentUser.getId().equals(song.getUser().getId())) {
+            throw new SongException(SongsExceptionCode.SONG_OWNERSHIP_EXCEPTION);
         }
 
         songRepository.delete(song);

--- a/src/main/java/org/example/merong/domain/songs/dto/response/SongResponseDto.java
+++ b/src/main/java/org/example/merong/domain/songs/dto/response/SongResponseDto.java
@@ -2,15 +2,20 @@ package org.example.merong.domain.songs.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.example.merong.domain.songs.dto.request.SongRequestDto;
+import org.example.merong.domain.comments.dto.response.CommentResponseDto;
 import org.example.merong.domain.songs.entity.Song;
 import org.example.merong.domain.songs.enums.Genres;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
 public class SongResponseDto {
+
+    @Getter
+    public static class Create {
 
     /*
      PK
@@ -19,43 +24,99 @@ public class SongResponseDto {
      가수
      장르
      작성일(발매일)
-     수정일
-     좋아요 수
-     재생 수
      설명
      */
 
     private final Long id;
-
     private final Long userId;
-
     private final String name;
-
     private final String singer;
-
     private final Genres genre;
-
     private final LocalDateTime createdAt;
-
-    private final LocalDateTime updatedAt;
-
-    private final Long likeCount;
-
-    private final Long playCount;
-
     private final String description;
 
-    public SongResponseDto(Song song) {
+    public Create(Song song) {
         this.id = song.getId();
         this.userId = song.getUser().getId();
         this.name = song.getName();
         this.singer = song.getSinger();
         this.genre = song.getGenre();
         this.createdAt = song.getCreatedAt();
-        this.updatedAt = song.getUpdatedAt();
-        this.likeCount = song.getLikeCount();
-        this.playCount = song.getPlayCount();
         this.description = song.getDescription();
     }
 
+    }
+
+    @Getter
+    public static class Get {
+
+        /*
+        PK
+        유저 PK
+        노래 제목
+        가수
+        장르
+        작성일(발매일)
+        수정일
+        좋아요 수
+        재생 수
+        설명
+        댓글 목록
+         */
+
+        private final Long id;
+        private final Long userId;
+        private final String name;
+        private final String singer;
+        private final Genres genre;
+        private final LocalDateTime createdAt;
+        private final LocalDateTime updatedAt;
+        private final Long likeCount;
+        private final Long playCount;
+        private final String description;
+        private final List<CommentResponseDto.Get> comments;
+
+        public Get(Song song) {
+            this.id = song.getId();
+            this.userId = song.getUser().getId();
+            this.name = song.getName();
+            this.singer = song.getSinger();
+            this.genre = song.getGenre();
+            this.createdAt = song.getCreatedAt();
+            this.updatedAt = song.getUpdatedAt();
+            this.likeCount = song.getLikeCount();
+            this.playCount = song.getPlayCount();
+            this.description = song.getDescription();
+            this.comments = song.getComments().stream()
+                    .map(comment -> new CommentResponseDto.Get(
+                            comment.getUser().getId(),
+                            comment.getContent(),
+                            comment.getUpdatedAt()
+                    )).toList();
+        }
+    }
+
+    @Getter
+    public static class Update {
+
+        private final Long id;
+        private final Long userId;
+        private final String name;
+        private final String singer;
+        private final Genres genre;
+        private final LocalDateTime createdAt;
+        private final LocalDateTime updatedAt;
+        private final String description;
+
+        public Update(Song song) {
+            this.id = song.getId();
+            this.userId = song.getUser().getId();
+            this.name = song.getName();
+            this.singer = song.getSinger();
+            this.genre = song.getGenre();
+            this.createdAt = song.getCreatedAt();
+            this.updatedAt = song.getUpdatedAt();
+            this.description = song.getDescription();
+        }
+    }
 }

--- a/src/main/java/org/example/merong/domain/songs/exception/SongException.java
+++ b/src/main/java/org/example/merong/domain/songs/exception/SongException.java
@@ -1,0 +1,18 @@
+package org.example.merong.domain.songs.exception;
+
+import lombok.Getter;
+import org.example.merong.common.exception.BaseException;
+import org.example.merong.common.exception.ResponseCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class SongException extends BaseException {
+
+    private final ResponseCode responseCode;
+    private final HttpStatus httpStatus;
+
+    public SongException(ResponseCode responseCode) {
+        this.responseCode = responseCode;
+        this.httpStatus = responseCode.getStatus();
+    }
+}

--- a/src/main/java/org/example/merong/domain/songs/exception/SongsExceptionCode.java
+++ b/src/main/java/org/example/merong/domain/songs/exception/SongsExceptionCode.java
@@ -1,0 +1,19 @@
+package org.example.merong.domain.songs.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.merong.common.exception.ResponseCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum SongsExceptionCode implements ResponseCode {
+
+    SONG_NOT_FOUND(false, HttpStatus.NOT_FOUND, "해당 노래를 찾을 수 없습니다."),
+    SONG_OWNERSHIP_EXCEPTION(false, HttpStatus.FORBIDDEN, "자신의 컨텐츠에만 접근할 수 있습니다.");
+
+    private final boolean isSuccess;
+    private final HttpStatus status;
+    private final String message;
+
+}


### PR DESCRIPTION

## 작업 내역
- Service 단에서 예최러리를 Repository 단으로 변경
- 예외 처리 시 커스텀 에러코드로 리팩토링
- 노래 조회 시 댓글들도 같이 볼 수 있도록 수정
- 충돌 해결


## 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?